### PR TITLE
1 Add ability to reload script modules

### DIFF
--- a/examples/resolve_deps.py
+++ b/examples/resolve_deps.py
@@ -1,5 +1,6 @@
 from odin_sequencer import CommandSequenceManager
 from pathlib import Path
+import time
 
 def main():
 
@@ -10,6 +11,11 @@ def main():
     ]]
     
     csm = CommandSequenceManager(paths)
+
+    print('sleeping')
+    time.sleep(5) # Manually modify module code of a_three function while program is sleeping 
+
+    csm.reload() # Reload all modules
 
     csm.a_one()
     csm.a_two()

--- a/examples/resolve_deps.py
+++ b/examples/resolve_deps.py
@@ -1,6 +1,5 @@
 from odin_sequencer import CommandSequenceManager
 from pathlib import Path
-import time
 
 def main():
 
@@ -11,11 +10,6 @@ def main():
     ]]
     
     csm = CommandSequenceManager(paths)
-
-    print('sleeping')
-    time.sleep(5) # Manually modify module code of a_three function while program is sleeping 
-
-    csm.reload() # Reload all modules
 
     csm.a_one()
     csm.a_two()

--- a/examples/test_reload.py
+++ b/examples/test_reload.py
@@ -15,9 +15,9 @@ def main():
 
     csm.a_three(9.876)
 
-    input("Hit return")
+    input("Modify a_three function inside a.py and then hit return")
 
-    csm.reload()
+    csm.reload(examples_dir.joinpath('dependencies/a.py'))
 
     csm.a_three(5.678)
     csm.execute('a_three', 1.234, wibble='wobble')

--- a/examples/test_reload.py
+++ b/examples/test_reload.py
@@ -1,0 +1,27 @@
+from odin_sequencer import CommandSequenceManager
+from pathlib import Path
+import time
+import sys
+
+def main():
+
+    examples_dir = Path(__file__).resolve().parent
+
+    paths = [examples_dir.joinpath(seq_file) for seq_file in [
+        'dependencies/a.py', 'dependencies/b.py', 'dependencies/c.py', 'dependencies/d.py', 'dependencies/e.py'
+    ]]
+
+    csm = CommandSequenceManager(paths)
+
+    csm.a_three(9.876)
+
+    input("Hit return")
+
+    csm.reload()
+
+    csm.a_three(5.678)
+    csm.execute('a_three', 1.234, wibble='wobble')
+
+if __name__ == '__main__':
+
+    main()

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -60,7 +60,7 @@ class CommandSequenceManager:
         manager will then attempt to resolve all dependencies and make modules available. All
         module files in a directory are loaded if a path to a directory is specified.
 
-        :param paths: names of file and directory paths to load 
+        :param path_or_paths: names of file and directory paths to load 
         :param resolve: resolve loaded modules if True (default true)
         """
 
@@ -144,13 +144,37 @@ class CommandSequenceManager:
         if resolve:
             self.resolve()
 
-    def reload(self, resolve=True):
+    def reload(self, file_paths=None, resolve=True):
+        """Reload currently loaded modules.
+        
+        This method attempts to reload all or specific sequence modules currently loaded
+        into the manager. It does this by manually unloading all sequence modules and then
+        loading them again and resolving their dependencies. 
 
-        module_names = [name for name in self.modules]
+        :param file_paths: path(s) to sequence module file(s) that require loading (default: None) 
+        :param resolve: resolve loaded modules if True (default true)
+        """
+
+        if file_paths:
+            if not isinstance(file_paths, list):
+                file_paths = [file_paths]
+
+            for i in range(len(file_paths)):
+                file_path = file_paths[i]
+                if not isinstance(file_path, Path):
+                    file_paths[i] = Path(file_path)
+
+            module_names = [name.stem for name in file_paths]
+
+        else:
+            file_paths = list(self.file_paths.values())
+            module_names = [name for name in self.modules]
+
+        # Unload the modules by deleting them
         for name in module_names:
             del(self.modules[name])
 
-        self.load(list(self.file_paths.values()), resolve)
+        self.load(file_paths, resolve)
 
     def _retrieve_directory_files(self, directory_path):
         """Retrieve paths to all sequence files in a directory.

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -201,9 +201,12 @@ class CommandSequenceManager:
 
         for name in module_names:
             try:
+                # The byte-compiled file associated to the module must be deleted
+                # to ensure that the modified version of the module file is loaded
                 os.remove(importlib.util.cache_from_source(self.file_paths[name]))
-            except FileNotFoundError:
+            except (FileNotFoundError, OSError):
                 pass
+            
             del(self.modules[name])
             del(self.file_paths[name])
 

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -12,6 +12,7 @@ from importlib import invalidate_caches
 import inspect
 import sys
 from pathlib import Path
+import os
 
 from .exceptions import CommandSequenceError
 
@@ -190,12 +191,6 @@ class CommandSequenceManager:
 
         self._unload([file_path.stem for file_path in file_paths])
 
-        for file_path in file_paths:
-            print(str(file_path))
-            print("-----")
-            with open(file_path, 'r') as fp:
-                print(fp.read())
-
         self.load(file_paths, resolve)
 
     def _unload(self, module_names):
@@ -203,10 +198,12 @@ class CommandSequenceManager:
 
         :param: module_names: loaded modules that require unloading
         """
-        
-        invalidate_caches()
+
         for name in module_names:
-            print("Unloading " + name)
+            try:
+                os.remove(importlib.util.cache_from_source(self.file_paths[name]))
+            except FileNotFoundError:
+                pass
             del(self.modules[name])
             del(self.file_paths[name])
 

--- a/tests/test_odin_sequencer.py
+++ b/tests/test_odin_sequencer.py
@@ -3,7 +3,6 @@
 """Tests for odin_sequencer package."""
 
 import pytest
-import time
 
 from odin_sequencer import CommandSequenceManager, CommandSequenceError
 
@@ -151,25 +150,16 @@ def test_reload_with_module_name(shared_datadir, make_seq_manager, create_paths)
     file_path = shared_datadir.joinpath('test_reload.py')
 
     file_path.write_text("""provides = ['get_message']
-print("one")
 def get_message():
     return 'World Hello'""")
 
     manager = make_seq_manager('test_reload.py')
 
-    with open(file_path, 'w') as fp:
-        fp.write("""provides = ['get_message']
-print("two")
+    file_path.write_text("""provides = ['get_message']
 def get_message():
     return 'Hello World'""")
 
-    with open(file_path, 'r') as fp:
-        print(fp.read())
-
-    del(manager.get_message)
-
     manager.reload(module_names='test_reload')
-
     message = manager.get_message()
 
     assert message == 'Hello World'


### PR DESCRIPTION
Closes #1 

Adds the ability to reload modules that are currently loaded in the manager. It throws appropriate exceptions if modules that have not been loaded are attempted to be reloaded. Wrote unit tests to cover this functionality.