### PR TITLE
9 Add ability to interrogate sequence to get its arguments

### DIFF
--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -14,6 +14,7 @@ import os
 
 from pathlib import Path
 from functools import partial
+from inspect import signature
 from .exceptions import CommandSequenceError
 from .watcher import FileWatcherFactory
 
@@ -43,6 +44,7 @@ class CommandSequenceManager:
         self.modules = {}
         self.requires = {}
         self.provides = {}
+        self.sequence_signatures = {}
         self.context = {}
         self.file_paths = {}
         self.auto_reload = False
@@ -124,6 +126,8 @@ class CommandSequenceManager:
                     seq_alias = seq_name + '_'
                     setattr(self, seq_alias, getattr(module, seq_name))
                     setattr(self, seq_name, partial(self.execute, seq_alias))
+                    # Extract the parameters and their types that the sequence accepts
+                    self.sequence_signatures[seq_name] = signature(getattr(module, seq_name))
                 except AttributeError:
                     raise CommandSequenceError(
                         "{} does not implement {} listed in its provided sequences".format(

--- a/tests/data/context_data/context_sequences.py
+++ b/tests/data/context_data/context_sequences.py
@@ -2,7 +2,7 @@
 
 provides = ['context_access', 'missing_context_obj']
 
-def context_access(value):
+def context_access(value:int=0):
     """Calls context increment method with the value passed as an argument, returing value."""
 
     ctx_obj = get_context('context_object')
@@ -11,4 +11,3 @@ def context_access(value):
 def missing_context_obj():
 
     ctx_obj = get_context('missing_context_object')
-

--- a/tests/test_odin_sequencer.py
+++ b/tests/test_odin_sequencer.py
@@ -12,6 +12,7 @@ that the separate thread on which the file watcher runs is stopped.
 import time
 import os
 import importlib.util
+import inspect
 import pytest
 
 from odin_sequencer import CommandSequenceManager, CommandSequenceError
@@ -97,6 +98,7 @@ def test_empty_manager(make_seq_manager):
     assert len(manager.provides) == 0
     assert len(manager.requires) == 0
     assert len(manager.context) == 0
+    assert len(manager.sequence_signatures) == 0
 
 
 def test_basic_manager_loaded(make_seq_manager):
@@ -105,10 +107,15 @@ def test_basic_manager_loaded(make_seq_manager):
     correct sequence functions.
     """
     manager = make_seq_manager('basic_sequences.py')
+    basic_return_value_seq_params = manager.sequence_signatures['basic_return_value'].parameters
 
     assert len(manager.modules) == 1
     assert len(manager.provides) == 1
     assert len(manager.requires) == 1
+    assert len(manager.sequence_signatures) == 3
+    assert len(basic_return_value_seq_params) == 1
+    assert 'value' in basic_return_value_seq_params
+    assert basic_return_value_seq_params['value'].default is inspect.Parameter.empty
     assert hasattr(manager, 'basic_read')
     assert hasattr(manager, 'basic_write')
 
@@ -632,6 +639,7 @@ def test_access_context_in_sequence(make_seq_manager, context_object):
     Test that accessing a context in a sequence works as as expected.
     """
     manager = make_seq_manager('context_data/context_sequences.py')
+    context_access_seq_params = manager.sequence_signatures['context_access'].parameters
     obj_name = 'context_object'
     manager.add_context(obj_name, context_object)
 
@@ -639,6 +647,11 @@ def test_access_context_in_sequence(make_seq_manager, context_object):
     return_val = manager.context_access(value)
 
     assert return_val == value + 1
+    assert len(manager.sequence_signatures) == 2
+    assert len(manager.sequence_signatures['missing_context_obj'].parameters) == 0
+    assert len(context_access_seq_params) == 1
+    assert 'value' in context_access_seq_params
+    assert context_access_seq_params['value'].default == 0
 
 
 def test_get_missing_context_object(make_seq_manager):

--- a/tests/test_odin_sequencer.py
+++ b/tests/test_odin_sequencer.py
@@ -98,7 +98,7 @@ def test_empty_manager(make_seq_manager):
     assert len(manager.provides) == 0
     assert len(manager.requires) == 0
     assert len(manager.context) == 0
-    assert len(manager.sequence_signatures) == 0
+    assert len(manager.sequences) == 0
 
 
 def test_basic_manager_loaded(make_seq_manager):
@@ -107,15 +107,16 @@ def test_basic_manager_loaded(make_seq_manager):
     correct sequence functions.
     """
     manager = make_seq_manager('basic_sequences.py')
-    basic_return_value_seq_params = manager.sequence_signatures['basic_return_value'].parameters
+    basic_return_value_seq_params = manager.sequences['basic_return_value']
 
     assert len(manager.modules) == 1
     assert len(manager.provides) == 1
     assert len(manager.requires) == 1
-    assert len(manager.sequence_signatures) == 3
+    assert len(manager.sequences) == 3
     assert len(basic_return_value_seq_params) == 1
-    assert 'value' in basic_return_value_seq_params
-    assert basic_return_value_seq_params['value'].default is inspect.Parameter.empty
+    assert basic_return_value_seq_params['value']['default'] is None
+    assert basic_return_value_seq_params['value']['type'] is None
+    assert basic_return_value_seq_params['value']['value'] is None
     assert hasattr(manager, 'basic_read')
     assert hasattr(manager, 'basic_write')
 
@@ -639,7 +640,7 @@ def test_access_context_in_sequence(make_seq_manager, context_object):
     Test that accessing a context in a sequence works as as expected.
     """
     manager = make_seq_manager('context_data/context_sequences.py')
-    context_access_seq_params = manager.sequence_signatures['context_access'].parameters
+    context_access_seq_params = manager.sequences['context_access']
     obj_name = 'context_object'
     manager.add_context(obj_name, context_object)
 
@@ -647,11 +648,12 @@ def test_access_context_in_sequence(make_seq_manager, context_object):
     return_val = manager.context_access(value)
 
     assert return_val == value + 1
-    assert len(manager.sequence_signatures) == 2
-    assert len(manager.sequence_signatures['missing_context_obj'].parameters) == 0
+    assert len(manager.sequences) == 2
+    assert len(manager.sequences['missing_context_obj']) == 0
     assert len(context_access_seq_params) == 1
-    assert 'value' in context_access_seq_params
-    assert context_access_seq_params['value'].default == 0
+    assert context_access_seq_params['value']['default'] == 0
+    assert context_access_seq_params['value']['type'] == 'int'
+    assert context_access_seq_params['value']['value'] == 0
 
 
 def test_get_missing_context_object(make_seq_manager):


### PR DESCRIPTION
Closes #9 

Adds the ability to extract the parameters (and their types) that a sequence accepts and stores these in dictionary.

This is the structure of the dictionary, showing the signature objects for the different sequences that are available in the manager:
![image](https://user-images.githubusercontent.com/45173816/94273289-1e518100-ff3c-11ea-9359-69c095f47452.png)


And this is the structure of a parameter object, showing the name of the parameter and its default value:
![image](https://user-images.githubusercontent.com/45173816/94273453-58bb1e00-ff3c-11ea-9359-1845c154a5b0.png)

