### PR TITLE
11 Attribute error raised when newly added sequence programmatically called

### DIFF
--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -343,10 +343,8 @@ class CommandSequenceManager:
             file_paths.append(file_path)
 
         if file_paths:
-            self.auto_reloading = True
             self.file_watcher.remove_watch(file_paths)
             self.reload(file_paths)
-            self.auto_reloading = False
 
     def add_context(self, name, obj):
         """Add an object to the manager context.
@@ -379,12 +377,13 @@ class CommandSequenceManager:
         """Solves the problem with AttributeError being raised when a newly added module sequence
         is programmatically called while auto-reload is enabled.
 
-        If a new sequence is added to a module while the auto-reload is enabled, an attribute of 
-        that sequence will not be added to the manager until the reload logic is not executed in
-        the execute function. As a result, programmatically calling the attribute for that sequence 
-        raises AttributeError. By deafult __getattr__ is called whenever a missing attribute is 
-        called, therefore the logic here attempts to reload modules that require reloading. 
-        AttributeError is raised if the sequence does not exist after reloading is attempted.
+        If a new sequence is added to a module while the auto-reload is enabled, an attribute
+        of that sequence will not be added to the manager until the reload logic is not executed
+        in the execute function. As a result, programmatically calling the attribute for that
+        sequence raises AttributeError. By deafult __getattr__ is called whenever a missing
+        attribute is called, therefore the logic here attempts to reload modules that require
+        reloading. AttributeError is raised if the sequence attribute does not exist after
+        reloading is attempted.
 
         :param name: name of the missing attribute
         """

--- a/tests/test_odin_sequencer.py
+++ b/tests/test_odin_sequencer.py
@@ -508,8 +508,10 @@ def test_execute_when_module_is_modified_while_auto_reload_enabled(shared_datadi
     _await_queue_size(manager, 1)
 
     message = manager.execute('generate_message')
+    basic_seq_value = manager.basic_sequence(0)
 
     assert message == 'Message: Hello World'
+    assert basic_seq_value == 0
 
     manager.disable_auto_reload()
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -17,9 +17,12 @@ def modify_test_reload_module_file(shared_datadir):
     time.sleep(0.1)
     module = shared_datadir.joinpath('test_reload.py')
 
-    module.write_text("""provides = ['get_message']
+    module.write_text("""provides = ['get_message', 'basic_sequence']
 def get_message():
-    return 'Hello World'""")
+    return 'Hello World'
+ 
+def basic_sequence(value):
+    return value""")
 
 
 def modify_with_dependency_module_file(shared_datadir):


### PR DESCRIPTION
Closes #11 

Implements logic in `__getattr__`, which by default is executed when a missing attribute is called, that will attempt to reload the modules inside the filewatcher's `modified_files_queue`. `AttributeError` is raised if the attribute is still missing after reloading is attempted. 