### PR TITLE
13 Require default values for all sequence parameters

### DIFF
--- a/examples/dependencies/a.py
+++ b/examples/dependencies/a.py
@@ -10,5 +10,5 @@ def a_two():
     print("a_two")
     d_two()
 
-def a_three(arg, wibble="hmm"):
+def a_three(arg=0, wibble="hmm"):
     print("a_three: arg={} wibble={}".format(arg, wibble))

--- a/examples/resolve_deps.py
+++ b/examples/resolve_deps.py
@@ -8,13 +8,13 @@ def main():
     paths = [examples_dir.joinpath(seq_file) for seq_file in [
         'dependencies/a.py', 'dependencies/b.py', 'dependencies/c.py', 'dependencies/d.py', 'dependencies/e.py'
     ]]
-    
+
     csm = CommandSequenceManager(paths)
 
     csm.a_one()
     csm.a_two()
     csm.a_three(5.678)
-    csm.execute('a_three', 1.234, wibble='wobble')
+    csm.execute('a_three', arg=1.234, wibble='wobble')
 
 if __name__ == '__main__':
 

--- a/examples/sequences/example_sequences.py
+++ b/examples/sequences/example_sequences.py
@@ -1,7 +1,7 @@
 requires = ['spi_commands']
 provides = ['test_sequence', 'another_sequence']
 
-def test_sequence(a_val:int=123, b:str='hello'):
+def test_sequence(a_val=123, b='hello'):
 
     print("Running test sequence")
 
@@ -21,6 +21,6 @@ def test_sequence(a_val:int=123, b:str='hello'):
     reg_val += 1
     dev.write_reg(0x33, reg_val)
 
-def another_sequence(c_val:bool=False, d=1.234):
+def another_sequence(c_val=False, d=1.234):
 
     pass

--- a/examples/sequences/spi_commands.py
+++ b/examples/sequences/spi_commands.py
@@ -1,10 +1,10 @@
 provides = ['spi_read', 'spi_write']
 
-def spi_read(num_bytes:int=1):
+def spi_read(num_bytes=1):
 
     print("Called spi_read for {} bytes".format(num_bytes))
     return list(range(num_bytes))
 
-def spi_write(vals:list=[0x1]):
+def spi_write(vals=[0x1]):
 
     print("Called spi_write for {}".format(vals))

--- a/examples/test_reload.py
+++ b/examples/test_reload.py
@@ -20,7 +20,7 @@ def main():
     csm.reload(examples_dir.joinpath('dependencies/a.py'))
 
     csm.a_three(5.678)
-    csm.execute('a_three', 1.234, wibble='wobble')
+    csm.execute('a_three', arg=1.234, wibble='wobble')
 
 if __name__ == '__main__':
 

--- a/tests/data/basic_sequences.py
+++ b/tests/data/basic_sequences.py
@@ -11,6 +11,6 @@ def basic_write():
 
     print("Basic write")
 
-def basic_return_value(value):
+def basic_return_value(value=0):
 
     return value

--- a/tests/data/context_data/context_sequences.py
+++ b/tests/data/context_data/context_sequences.py
@@ -2,7 +2,7 @@
 
 provides = ['context_access', 'missing_context_obj']
 
-def context_access(value:int=0):
+def context_access(value=0):
     """Calls context increment method with the value passed as an argument, returing value."""
 
     ctx_obj = get_context('context_object')

--- a/tests/data/missing_default_param_value.py
+++ b/tests/data/missing_default_param_value.py
@@ -1,0 +1,7 @@
+# Command sequence for testing CommandSequenceManager without a default paramater value
+
+provides = ['basic_seq']
+
+def basic_seq(val):
+
+    return val

--- a/tests/test_odin_sequencer.py
+++ b/tests/test_odin_sequencer.py
@@ -12,7 +12,6 @@ that the separate thread on which the file watcher runs is stopped.
 import time
 import os
 import importlib.util
-import inspect
 import pytest
 
 from odin_sequencer import CommandSequenceManager, CommandSequenceError
@@ -114,9 +113,9 @@ def test_basic_manager_loaded(make_seq_manager):
     assert len(manager.requires) == 1
     assert len(manager.sequences) == 3
     assert len(basic_return_value_seq_params) == 1
-    assert basic_return_value_seq_params['value']['default'] is None
-    assert basic_return_value_seq_params['value']['type'] is None
-    assert basic_return_value_seq_params['value']['value'] is None
+    assert basic_return_value_seq_params['value']['default'] == 0
+    assert basic_return_value_seq_params['value']['type'] == 'int'
+    assert basic_return_value_seq_params['value']['value'] == 0
     assert hasattr(manager, 'basic_read')
     assert hasattr(manager, 'basic_write')
 
@@ -516,10 +515,7 @@ def test_execute_when_module_is_modified_while_auto_reload_enabled(shared_datadi
     _await_queue_size(manager, 1)
 
     message = manager.execute('generate_message')
-    basic_seq_value = manager.basic_sequence(0)
-
     assert message == 'Message: Hello World'
-    assert basic_seq_value == 0
 
     manager.disable_auto_reload()
 
@@ -583,6 +579,25 @@ def test_attribute_func_when_module_is_modified_while_auto_reload_enabled(shared
     message = manager.generate_message()
 
     assert message == 'Message: Hello World'
+
+    manager.disable_auto_reload()
+
+
+def test_attribute_func_when_module_sequence_is_added_auto_reload_enabled(shared_datadir,
+                                                                          make_seq_manager,
+                                                                          create_tmp_module_files):
+    """
+    Test that a module that has been modified to provide a new sequence while auto reloading is
+    enabled is reloaded when the newly added sequence is called through the manager attribute.
+    """
+    tmp_files = create_tmp_module_files
+    manager = make_seq_manager(tmp_files)
+    manager.enable_auto_reload()
+    modify_test_reload_module_file(shared_datadir)
+    _await_queue_size(manager, 1)
+
+    basic_seq_value = manager.basic_sequence(1)
+    assert basic_seq_value == 1
 
     manager.disable_auto_reload()
 

--- a/tests/test_odin_sequencer.py
+++ b/tests/test_odin_sequencer.py
@@ -196,6 +196,21 @@ def test_load_with_missing_directory(shared_datadir, make_seq_manager):
         make_seq_manager(directory_path)
 
 
+def test_load_with_sequence_that_has_no_paramater_default_value(make_seq_manager):
+    """
+    Test that loading a module file that has a sequence with no default paramater
+    value raises an error appropriately.
+    """
+    file_name = 'missing_default_param_value.py'
+    sqe_name = 'basic_seq'
+    param_name = 'val'
+    with pytest.raises(
+            CommandSequenceError, match="'{}' parameter in '{}' sequence does not have a default "
+                                        "value".format(param_name, sqe_name)
+    ):
+        make_seq_manager(file_name)
+
+
 def test_explicit_module_load(make_seq_manager, create_paths):
     """
     Test that a module file is loaded into the manager when the load function

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -21,7 +21,7 @@ def modify_test_reload_module_file(shared_datadir):
 def get_message():
     return 'Hello World'
  
-def basic_sequence(value):
+def basic_sequence(value=0):
     return value""")
 
 


### PR DESCRIPTION
Closes #13 

Changes the way that the manager works in that it will not load a module but raise an error if one of its sequence has a parameter that does not have a default value. This is so that issues with modifying the values of parameters in the ODIN `ParameterTree` can be avoided later.