### PR TITLE
17 Prevent sequences that have list parameters with heterogeneous elements from being loaded

### DIFF
--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -117,6 +117,13 @@ class CommandSequenceManager:
                 provides = [name for name, _ in inspect.getmembers(module, inspect.isfunction)]
 
             for seq_name in provides:
+                # Do not load the sequence if one with the same name has already been registered
+                if any(seq_name in val for val in self.provides.values()):
+                    raise CommandSequenceError(
+                        "Unable to load sequence '{}' from module '{}' as a sequence with the "
+                        "same name has already being registered".format(seq_name, module_name)
+                    )
+
                 # Set the provided functions as attributes of this manager, so they are available
                 # to be used by calling code. A reference to a partial function is set which calls
                 # the execute function instead of the sequence function directly. This ensures
@@ -314,6 +321,8 @@ class CommandSequenceManager:
                 del self.sequences[provided]
 
             del self.modules[name]
+            del self.provides[name]
+            del self.requires[name]
             del self.file_paths[name]
 
     def enable_auto_reload(self):

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -226,7 +226,7 @@ class CommandSequenceManager:
         param list_val: the list that needs to be checked
         :return: True if the list are of the same type, otherwise False
         """
-        return not any(not isinstance(list_val[0], type(element)) for element in list_val)
+        return not any(not type(element) == type(list_val[0]) for element in list_val)
 
     def _build_sequence_parameter_info(self, params):
         """This method builds a dictionary that contains the parameter

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -221,22 +221,28 @@ class CommandSequenceManager:
         """
         return not any(not isinstance(list_val[0], type(element)) for element in list_val)
 
-    @staticmethod
-    def _build_sequence_parameter_info(params):
+    def _build_sequence_parameter_info(self, params):
         """This method builds a dictionary that contains the parameter
         names that a sequence accepts, and their type and default value.
 
         :param params: the parameter(s) to extract and build information for
         :return: a dictionary with information about the parameters that the sequence accepts
         """
-
         return {
             param.name: {
                 "value": param.default,
                 "default": param.default,
-                "type": type(param.default).__name__
+                "type": self._get_parameter_type(param.default)
             } for param in params
         }
+
+    @staticmethod
+    def _get_parameter_type(param_default_val):
+        param_type = type(param_default_val).__name__
+        if param_type == 'list':
+            param_type = 'list-{}'.format(type(param_default_val[0]).__name__)
+
+        return param_type
 
     def reload(self, file_paths=None, module_names=None, resolve=True):
         """Reload currently loaded modules.

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -181,12 +181,36 @@ class CommandSequenceManager:
                         param.name, seq_name)
                 )
 
-            if type(param.default).__name__ == 'list' and not self._is_list_homogeneous(
-                    param.default):
-                raise CommandSequenceError(
-                    "'{}' list parameter in '{}' sequence contains elements of different "
-                    "types".format(param.name, seq_name)
+            if type(param.default).__name__ == 'list':
+                self._validate_list_parameter(seq_name, param)
+
+    def _validate_list_parameter(self, seq_name, param):
+        """ Validate a list parameter of a sequence.
+
+        This method validates a list parameter of a sequence and ensures that it is not empty,
+        does not contain a list element or elements of different types. It raises exceptions if
+        any of these validations fail.
+
+        :param param: the list parameter that needs to be validated
+        :param seq_name: the name of the sequence to which the list parameter belongs to
+        """
+        if len(param.default) == 0:
+            raise CommandSequenceError(
+                "'{}' list parameter in '{}' sequence is empty".format(param.name, seq_name)
+            )
+
+        if any(isinstance(element, list) for element in param.default):
+            raise CommandSequenceError(
+                "'{}' list parameter in '{}' sequence contains a list element".format(
+                    param.name, seq_name
                 )
+            )
+
+        if not self._is_list_homogeneous(param.default):
+            raise CommandSequenceError(
+                "'{}' list parameter in '{}' sequence contains elements of different "
+                "types".format(param.name, seq_name)
+            )
 
     @staticmethod
     def _is_list_homogeneous(list_val):

--- a/tests/data/empty_list_param.py
+++ b/tests/data/empty_list_param.py
@@ -1,0 +1,8 @@
+# Command sequence for testing CommandSequenceManager with a sequence that has
+# a list parameter whose default value contains no elements
+
+provides = ['basic_seq']
+
+def basic_seq(val=[]):
+
+    return val

--- a/tests/data/list_param_contains_heterogeneous_elements.py
+++ b/tests/data/list_param_contains_heterogeneous_elements.py
@@ -1,0 +1,8 @@
+# Command sequence for testing CommandSequenceManager with a sequence that has
+# a list parameter whose default value contains elements of different types
+
+provides = ['basic_seq']
+
+def basic_seq(val=[1, False]):
+
+    return val

--- a/tests/data/list_param_contains_list_element.py
+++ b/tests/data/list_param_contains_list_element.py
@@ -1,0 +1,8 @@
+# Command sequence for testing CommandSequenceManager with a sequence that has
+# a list parameter whose default value contains no elements
+
+provides = ['basic_seq']
+
+def basic_seq(val=[[]]):
+
+    return val

--- a/tests/test_odin_sequencer.py
+++ b/tests/test_odin_sequencer.py
@@ -882,7 +882,7 @@ def test_attribute_func_when_module_sequence_is_added_auto_reload_enabled(shared
 
     basic_seq_value = manager.basic_sequence([0, 1])
     assert basic_seq_value == [0, 1]
-    assert manager.sequences['basic_sequence']['value']['type'] == 'list-int'
+    assert manager.sequence_modules['test_reload']['basic_sequence']['value']['type'] == 'list-int'
 
     manager.disable_module_watching()
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -21,7 +21,7 @@ def modify_test_reload_module_file(shared_datadir):
 def get_message():
     return 'Hello World'
  
-def basic_sequence(value=0):
+def basic_sequence(value=[1]):
     return value""")
 
 


### PR DESCRIPTION
Closes #17 

Prevents loading of modules that have sequences with list parameters which have:

- no elements
- list element
- heterogeneous elements

Also prevents loading of modules if a sequence is named the same as one that has already been loaded in the manager.