### PR TITLE
Adapter context

### DIFF
--- a/config/odin_sequencer.cfg
+++ b/config/odin_sequencer.cfg
@@ -3,7 +3,7 @@ debug_mode = 1
 http_port  = 8888
 http_addr  = 127.0.0.1
 static_path = ./static
-adapters   = odin_sequencer
+adapters   = odin_sequencer, dummy_context
 
 [tornado]
 logging = debug
@@ -11,3 +11,6 @@ logging = debug
 [adapter.odin_sequencer]
 module = odin_sequencer.adapter.CommandSequenceManagerAdapter
 sequence_location = ./examples/sequences
+
+[adapter.dummy_context]
+module = odin_sequencer.dummy_context.DummyContextAdapter

--- a/src/odin_sequencer/adapter.py
+++ b/src/odin_sequencer/adapter.py
@@ -84,3 +84,10 @@ class CommandSequenceManagerAdapter(ApiAdapter):
 
         return ApiAdapterResponse(response, content_type=content_type,
                                   status_code=status_code)
+
+    def add_context(self, name, obj):
+        """This method adds an object to the manager context.
+        :param name: Name of context
+        :param obj: Context object
+        """
+        self.command_sequencer._add_context(name, obj)

--- a/src/odin_sequencer/command_sequencer.py
+++ b/src/odin_sequencer/command_sequencer.py
@@ -227,6 +227,7 @@ class CommandSequencer:
         try:
             self.manager.execute(seq_name, **kwargs)
         except CommandSequenceError as error:
+            self.manager.log_message('<b style="color:red">Execution error</b>: {}: {}'.format(seq_name, error))
             raise CommandSequenceError('A problem occurred during the execution of {}: {}'.format(seq_name, error))
         finally:
             self.is_executing = False

--- a/src/odin_sequencer/command_sequencer.py
+++ b/src/odin_sequencer/command_sequencer.py
@@ -303,6 +303,10 @@ class CommandSequencer:
             list_val = map(self._val_to_float, list_val)
 
         return list(list_val)
+    
+    def _add_context(self, name, obj):
+        """This method adds an object to the manager context."""
+        self.manager.add_context(name, obj)
 
     @staticmethod
     def _val_to_bool(val):

--- a/src/odin_sequencer/command_sequencer.py
+++ b/src/odin_sequencer/command_sequencer.py
@@ -224,8 +224,12 @@ class CommandSequencer:
         self.thread.start()
 
     def _execute(self, seq_name, **kwargs):
-        self.manager.execute(seq_name, **kwargs)
-        self.is_executing = False
+        try:
+            self.manager.execute(seq_name, **kwargs)
+        except CommandSequenceError as error:
+            raise CommandSequenceError('A problem occurred during the execution of {}: {}'.format(seq_name, error))
+        finally:
+            self.is_executing = False
 
     def log(self, *args, **kwargs):
         """This method is register as an external logger with the manager. Doing this results

--- a/src/odin_sequencer/dummy_context.py
+++ b/src/odin_sequencer/dummy_context.py
@@ -1,0 +1,126 @@
+"""Demo adapter for ODIN sequencer 
+
+This class implements a simple adapter used for demonstrating how a context can be
+added to the odin sequencer.
+
+Rhys Evans, STFC
+"""
+import logging
+import tornado
+import time
+import sys
+from concurrent import futures
+
+from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.concurrent import run_on_executor
+from tornado.escape import json_decode
+
+from odin.adapters.adapter import ApiAdapter, ApiAdapterResponse, request_types, response_types
+
+
+class DummyContextAdapter(ApiAdapter):
+    """Dummy context adapter class for the ODIN server.
+
+    This adapter provides a TestDevice context to the odin sequencer.
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize the DummyContextAdapter object.
+
+        This constructor initializes the DummyContextAdapter object.
+
+        :param kwargs: keyword arguments specifying options
+        """
+        # Intialise superclass
+        super(DummyContextAdapter, self).__init__(**kwargs)
+
+        self.adapters = {}
+
+        logging.debug('DummyContextAdapter loaded')
+
+    @response_types('application/json', default='application/json')
+    def get(self, path, request):
+        """Handle an HTTP GET request.
+
+        This method handles an HTTP GET request, returning a JSON response.
+
+        :param path: URI path of request
+        :param request: HTTP request object
+        :return: an ApiAdapterResponse object containing the appropriate response
+        """
+        try:
+            response[path] = self.adapters['odin_sequencer'].get(path, request).data
+            status_code = 200
+        except Exception as e:
+            response = {'error': str(e)}
+            status_code = 400
+
+        content_type = 'application/json'
+
+        return ApiAdapterResponse(response, content_type=content_type,
+                                  status_code=status_code)
+
+    @request_types('application/json')
+    @response_types('application/json', default='application/json')
+    def put(self, path, request):
+        """Handle an HTTP PUT request.
+
+        This method handles an HTTP PUT request, returning a JSON response.
+
+        :param path: URI path of request
+        :param request: HTTP request object
+        :return: an ApiAdapterResponse object containing the appropriate response
+        """
+        content_type = 'application/json'
+        try:
+            body = decode_request_body(request)
+            response = {}
+            request = ApiAdapterRequest(body)
+            response[path] = self.adapters['odin_sequencer'].put(path, request).data
+            status_code = 200
+        except DummyContextError as e:
+            response = {'error': str(e)}
+            status_code = 400
+        except (TypeError, ValueError) as e:
+            response = {'error': 'Failed to decode PUT request body: {}'.format(str(e))}
+            status_code = 400
+
+        logging.debug(response)
+
+        return ApiAdapterResponse(response, content_type=content_type,
+                                  status_code=status_code)
+
+    def initialize(self, adapters):
+        """Initialize the adapter after it has been loaded and added TestDevice context to sequencer.
+
+        Receive a dictionary of all loaded adapters so that they may be accessed by this adapter.
+        Remove itself from the dictionary so that it does not reference itself, as doing so
+        could end with an endless recursive loop.
+        """
+
+        self.adapters = dict((k, v) for k, v in adapters.items() if v is not self)
+        logging.debug("Received following dict of Adapters: %s", self.adapters)
+        
+        test_device = TestDevice(123)
+        self.adapters['odin_sequencer'].add_context('test_device', test_device)
+        logging.debug("Test device context added to odin sequencer.")
+
+
+class DummyContextError(Exception):
+    """Simple exception class to wrap lower-level exceptions."""
+
+    pass
+
+
+class TestDevice():
+
+    def __init__(self, val):
+        self.val = val
+
+    def read_reg(self):
+        print("In read reg")
+        return self.val
+
+    def write_reg(self, reg, vals):
+        print("In write reg with reg {} vals {}".format(reg, vals))
+

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -531,6 +531,8 @@ class CommandSequenceManager:
             raise CommandSequenceError(
                 'Missing command sequence: {}'.format(sequence_name)
             )
+        except CommandSequenceError as error:
+            self.log_message('<b style="color:red">Execution error</b>: {}: {}'.format(sequence_name, error))
 
     def add_context(self, name, obj):
         """Add an object to the manager context.

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -532,7 +532,7 @@ class CommandSequenceManager:
                 'Missing command sequence: {}'.format(sequence_name)
             )
         except CommandSequenceError as error:
-            self.log_message('<b style="color:red">Execution error</b>: {}: {}'.format(sequence_name, error))
+            raise error
 
     def add_context(self, name, obj):
         """Add an object to the manager context.

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -4,7 +4,26 @@ from unittest.mock import Mock, MagicMock, patch
 
 from odin_sequencer import CommandSequenceError
 from src.odin_sequencer.adapter import CommandSequenceManagerAdapter
+import pytest
 
+@pytest.fixture
+def context_object():
+    """
+    Test fixture for creating a simple container object that can be loaded into
+    the sequence manager context and accessed for test.
+    """
+
+    class ContextObject():
+        """An example of a context object"""
+
+        def __init__(self, value):
+            self.value = value
+
+        def increment(self, val):
+            """Increments a given value by 1"""
+            return val + 1
+
+    return ContextObject(255374)
 
 class TestCommandSequenceManagerAdapter:
 
@@ -86,3 +105,12 @@ class TestCommandSequenceManagerAdapter:
         self.command_sequencer_mock.set.assert_not_called()
 
         json_decode_mock.reset_mock(return_value=True, side_effect=True)
+
+
+    def test_add_context(self, context_object):
+
+        obj_name = 'context_object'
+        self.adapter.add_context(obj_name, context_object)
+        
+        self.command_sequencer_mock._add_context.assert_called_once_with(obj_name, context_object)
+        self.command_sequencer_mock.get.reset_mock(return_value=True, side_effect=True)

--- a/tests/test_command_sequencer.py
+++ b/tests/test_command_sequencer.py
@@ -21,6 +21,24 @@ def create_command_sequencer(create_paths):
 
     return _create_command_sequencer
 
+@pytest.fixture
+def context_object():
+    """
+    Test fixture for creating a simple container object that can be loaded into
+    the sequence manager context and accessed for test.
+    """
+
+    class ContextObject():
+        """An example of a context object"""
+
+        def __init__(self, value):
+            self.value = value
+
+        def increment(self, val):
+            """Increments a given value by 1"""
+            return val + 1
+
+    return ContextObject(255374)
 
 def _await_execution_complete(command_sequencer):
     for _ in range(15, 0, -1):
@@ -526,3 +544,14 @@ def test_get_log_messages_with_last_message_timestamp(create_command_sequencer,
 
     assert len(log_messages) == 1
     assert log_messages[0][1] == 'Executing get_message'
+
+
+def test_add_context(create_command_sequencer, context_object):
+
+    command_sequencer = create_command_sequencer()
+    obj_name = 'context_object'
+    command_sequencer._add_context(obj_name, context_object)
+
+    assert obj_name in command_sequencer.manager.context
+    assert id(context_object) == id(command_sequencer.manager._get_context(obj_name))
+    assert context_object.value == command_sequencer.manager._get_context(obj_name).value


### PR DESCRIPTION
Added error handling for executing sequences. 

Added a dummy adapter to demonstrate how to add a context the the sequencer. 

Closes https://github.com/stfc-aeg/odin-sequencer/issues/23

![image](https://user-images.githubusercontent.com/34507919/99080578-65153c00-25b9-11eb-81ab-51d80ca0c525.png)
