### PR TITLE
Improve formatting of log messages in UI

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -25,7 +25,7 @@
         <div class="text-center">
           <h4>Log Messages</h4>
         </div>
-        <pre class="pre-scrollable" id="log-messages">&nbsp;</pre>
+        <pre class="pre-scrollable" id="log-messages"></pre>
       </div>
       <div class="col-md-1"></div>
     </div>

--- a/static/js/command_sequencer.js
+++ b/static/js/command_sequencer.js
@@ -304,9 +304,11 @@ function display_log_messages() {
         if (!jQuery.isEmptyObject(log_messages)) {
             last_message_timestamp = log_messages[log_messages.length - 1][0];
 
+            pre_scrollable_id = '#log-messages';
             for (log_message in log_messages) {
-                pre_scrollable_id = '#log-messages';
-                $(pre_scrollable_id).append(`<span style="color:#007bff">${log_messages[log_message][0]}</span> ${log_messages[log_message][1]}<br>`);
+                timestamp = log_messages[log_message][0];
+                timestamp = timestamp.substr(0, timestamp.length - 3);
+                $(pre_scrollable_id).append(`<span style="color:#007bff">${timestamp}</span> ${log_messages[log_message][1]}<br>`);
                 // Scrolls down
                 $(pre_scrollable_id).animate({ scrollTop: $(pre_scrollable_id).prop('scrollHeight') }, 1000);
             }


### PR DESCRIPTION
This PR addressess #29, improving the formatting of log messages in the UI. The first message is no longer indented by one space, and the subsecond timestamp on messages is truncated from micro- to millisecs.