### PR TITLE
Improve exception propagation and handling in command sequencer

### DIFF
--- a/src/odin_sequencer/command_sequencer.py
+++ b/src/odin_sequencer/command_sequencer.py
@@ -5,7 +5,7 @@ Module which facilitates communication to the command sequencer manager.
 Viktor Bozhinov, STFC.
 """
 
-
+import logging
 import threading
 
 from collections import deque
@@ -232,7 +232,7 @@ class CommandSequencer:
             self.manager.execute(seq_name, **kwargs)
         except CommandSequenceError as error:
             self.manager.log_message('<b style="color:red">Execution error</b>: {}: {}'.format(seq_name, error))
-            raise CommandSequenceError('A problem occurred during the execution of {}: {}'.format(seq_name, error))
+            logging.error("Sequence execution error: {}: {}".format(seq_name, error))
         finally:
             self.is_executing = False
 

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -525,14 +525,16 @@ class CommandSequenceManager:
             if modified_module_paths:
                 self.reload(modified_module_paths)
 
-        try:
-            return getattr(self, sequence_name)(*args, **kwargs)
-        except AttributeError:
-            raise CommandSequenceError(
+        if not hasattr(self, sequence_name):
+            raise  CommandSequenceError(
                 'Missing command sequence: {}'.format(sequence_name)
             )
+        try:
+            return getattr(self, sequence_name)(*args, **kwargs)
         except CommandSequenceError as error:
             raise error
+        except:
+            raise CommandSequenceError(sys.exc_info()[1])
 
     def add_context(self, name, obj):
         """Add an object to the manager context.


### PR DESCRIPTION
This PR addresses #28 and improves exception handling and error reporting in the manager and adapter. The following changes are made:

1) The manager discriminates between missing sequences and `AttributeError` exceptions being raised by sequences.
2) All exceptions occurring during execution of sequences are caught, and then re-thrown wrapped in a `CommandSequenceError`, ensuring that problem can be reported to the user via the UI
3) Such exceptions are logged as error messages in the UI message log and in the server log file, but not re-thrown, avoiding exception tracebacks in the odin_server log and allowing reporting to the user.