### PR TITLE
Update sequence manager load to report duplicate names in current file

### DIFF
--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -124,7 +124,8 @@ class CommandSequenceManager:
             sequences = {}
             for seq_name in provides:
                 # Do not load the sequence if one with the same name has already been registered
-                if any(seq_name in val for val in self.provides.values()):
+                if (any(seq_name in val for val in self.provides.values()) or   # Other files
+                        seq_name in sequences.keys()):                          # This file
                     raise CommandSequenceError(
                         "Unable to load sequence '{}' from module '{}' as a sequence with the "
                         "same name has already being registered".format(seq_name, module_name)


### PR DESCRIPTION
Previously, an error was raised if a sequence was encountered with the same name as one from a file previously loaded. However, duplicate names in the same file were not picked up until the *unload* stage, at which point the duplicate names broke the imported module.

This fix makes sure that having duplicate names in a single file will also trigger the same error.

Fixes #35 