### PR TITLE
Prevent manager from tying to create path from empty list

### DIFF
--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -77,6 +77,9 @@ class CommandSequenceManager:
 
         for path in path_or_paths:
 
+            if not path:
+                continue
+
             if not isinstance(path, Path):
                 path = Path(path)
 


### PR DESCRIPTION
Prevent the CommandSequenceManager from converting an empty (`None`) path list into path entities.

Closes #37