### PR TITLE
Add the ability to abort executing sequences

### DIFF
--- a/examples/sequences/example_sequences.py
+++ b/examples/sequences/example_sequences.py
@@ -1,5 +1,7 @@
 requires = ['spi_commands']
-provides = ['test_sequence', 'another_sequence']
+provides = ['test_sequence', 'another_sequence', 'abortable_sequence']
+
+import time
 
 def test_sequence(a_val=123, b='hello'):
 
@@ -30,3 +32,14 @@ def test_sequence(a_val=123, b='hello'):
 def another_sequence(c_val=False, d=1.234):
 
     pass
+
+def abortable_sequence(num_loops=10, loop_delay=1.0001):
+
+    for i in range(num_loops):
+        print("Loop count {}".format(i))
+        time.sleep(loop_delay)
+        if abort_sequence():
+            print("Aborting sequence")
+            break
+
+    print("Sequence complete")

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -51,6 +51,7 @@ class CommandSequenceManager:
         self.module_watching = False
         self.auto_reload = False
         self.external_logger = None
+        self._abort_sequence = False
 
         # If one or more files have been specified, attempt to load and resolve them
         if path_or_paths:
@@ -162,6 +163,7 @@ class CommandSequenceManager:
             # Set the manager context as an attribute of the module to allow access to external
             # functionality
             setattr(module, 'get_context', self._get_context)
+            setattr(module, 'abort_sequence', lambda: self._abort_sequence)
 
             # Add the module information to the manager
             self.modules[module_name] = module
@@ -590,3 +592,11 @@ class CommandSequenceManager:
             raise AttributeError("Manager has no attribute '{}'".format(name))
 
         return getattr(self, name)
+
+    @property
+    def abort_sequence(self):
+        return self._abort_sequence
+
+    @abort_sequence.setter
+    def abort_sequence(self, abort):
+        self._abort_sequence = abort

--- a/static/index.html
+++ b/static/index.html
@@ -36,7 +36,10 @@
           </div>
         </div>
         <div class="row mb-3">
-          <div class="col-md-8"></div>
+          <div class="col-md-6"></div>
+          <div class="col-md-2">
+            <button type="submit" class="btn btn-primary" onclick="abort_sequence()" id="abort-btn">Abort</button>
+          </div>
           <div class="col-md-2">
             <button type="submit" class="btn btn-primary" onclick="reload_modules()" id="reload-btn">Reload</button>
           </div>

--- a/static/js/command_sequencer.js
+++ b/static/js/command_sequencer.js
@@ -12,7 +12,8 @@ const ALERT_ID = {
 
 const BUTTON_ID = {
     'all_execute': '.execute-btn',
-    'reload': '#reload-btn'
+    'reload': '#reload-btn',
+    'abort': '#abort-btn'
 };
 
 /**
@@ -36,8 +37,13 @@ document.addEventListener("DOMContentLoaded", function () {
 
         if (is_executing) {
             disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, true);
+            disable_buttons(`${BUTTON_ID['abort']}`, false);
             await_execution_complete();
             await_process_execution_complete();
+        }
+        else
+        {
+            disable_buttons(`${BUTTON_ID['abort']}`, true);
         }
 
         set_detect_module_changes_toggle(detect_module_modifications);
@@ -134,6 +140,24 @@ function reload_modules() {
     });
 }
 
+function abort_sequence() {
+    hide_alerts(`${ALERT_ID['sequencer_info']},${ALERT_ID['sequencer_error']}`);
+
+    alert_id = '';
+    alert_message = '';
+    sequencer_endpoint.put({ 'abort': true })
+    .then(() => {
+        alert_id = ALERT_ID['sequencer_info'];
+        alert_message = "Abort sent to currently executing sequence";
+    })
+    .catch(error => {
+        alert_id = ALERT_ID['sequencer_error'];
+        alert_message = error.message;
+    })
+    .then(() => {
+        display_alert(alert_id, alert_message);
+    });
+}
 /**
  * This function replicates the equivalent jQuery isEmptyObject, returning true if the
  * object passed as an parameter is empty.
@@ -166,6 +190,7 @@ function execute_sequence(button) {
         .then(() => {
             hide_alerts(`${ALERT_ID['sequencer_info']},${ALERT_ID['sequencer_error']},.sequence-alert`);
             disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, true);
+            disable_buttons(`${BUTTON_ID['abort']}`, false);
 
             sequencer_endpoint.put({ 'execute': seq_name })
             .catch(error => {
@@ -193,7 +218,8 @@ function execute_sequence(button) {
         });
 
     } else {
-        disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, true)
+        disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, true);
+        disable_buttons(`${BUTTON_ID['abort']}`, false);
         sequencer_endpoint.put({ 'execute': seq_name })
         .catch(error => {
             alert_message = error.message;
@@ -271,6 +297,7 @@ function await_execution_complete() {
             setTimeout(await_execution_complete, 1000);
         } else {
             disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, false);
+            disable_buttons(`${BUTTON_ID['abort']}`, true);
         }
     });
 }


### PR DESCRIPTION
This PR addresses #39, adding the ability to abort currently executing sequences. This requires sequences to interrogate the `abort_sequence()` method (loaded into every sequence module scope) while looping, and break out of the loop when true.

The sequencer UI has also been updated to add an 'Abort' button, and and example sequences implemented demonstrating usage.
