### PR TITLE
Add the ability to display sequence execution progress

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ exposed to every loaded sequence module. If `true` the sequence can be cleanly t
 How to report progress in an executing sequence
 -----------------------------------------------
 
-Executing sequences can report progress to the user by calling the :code:`report_progress` function,
+Executing sequences can report progress to the user by calling the :code:`set_progress` function,
 which is exposed to every loaded sequence module. This takes two arguments reporting the `current`
 and `total` steps in the sequence. This is used by the API and UI to display progress. (See
 example_sequences.py for an example.)

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,20 @@ The context can now be used in a sequence by calling :code:`get_context` (see ex
 
     dev = get_context('test_device')
 
+How to abort an executing sequence
+----------------------------------
+
+Long-running sequences can choose to check the value of the :code:`abort_sequence()` function, which is
+exposed to every loaded sequence module. If `true` the sequence can be cleanly terminated early.
+(See example_sequences.py for an example of an abortable sequence.)
+
+How to report progress in an executing sequence
+-----------------------------------------------
+
+Executing sequences can report progress to the user by calling the :code:`report_progress` function,
+which is exposed to every loaded sequence module. This takes two arguments reporting the `current`
+and `total` steps in the sequence. This is used by the API and UI to display progress. (See
+example_sequences.py for an example.)
 
 How to start a local process worker
 -----------------------------------

--- a/config/odin_sequencer_noproc.cfg
+++ b/config/odin_sequencer_noproc.cfg
@@ -1,0 +1,16 @@
+[server]
+debug_mode = 1
+http_port  = 8888
+http_addr  = 127.0.0.1
+static_path = ./static
+adapters   = odin_sequencer, dummy_context
+
+[tornado]
+logging = debug
+
+[adapter.odin_sequencer]
+module = odin_sequencer.adapter.CommandSequenceManagerAdapter
+sequence_location = ./examples/sequences
+
+[adapter.dummy_context]
+module = odin_sequencer.dummy_context.DummyContextAdapter

--- a/examples/sequences/example_sequences.py
+++ b/examples/sequences/example_sequences.py
@@ -33,11 +33,16 @@ def another_sequence(c_val=False, d=1.234):
 
     pass
 
-def abortable_sequence(num_loops=10, loop_delay=1.0001):
+def abortable_sequence(num_loops=100, loop_delay=0.1):
+
+    set_progress(0, num_loops)
 
     for i in range(num_loops):
-        print("Loop count {}".format(i))
+        if i % 10 == 0:
+            print("Loop count {}".format(i))
+
         time.sleep(loop_delay)
+        set_progress(i+1, num_loops)
         if abort_sequence():
             print("Aborting sequence")
             break

--- a/examples/sequences/example_sequences.py
+++ b/examples/sequences/example_sequences.py
@@ -1,5 +1,5 @@
 requires = ['spi_commands']
-provides = ['test_sequence', 'another_sequence', 'abortable_sequence']
+provides = ['test_sequence', 'another_sequence', 'abortable_sequence', 'no_params']
 
 import time
 
@@ -48,3 +48,11 @@ def abortable_sequence(num_loops=100, loop_delay=0.1):
             break
 
     print("Sequence complete")
+
+def no_params():
+
+    set_progress(0, 10)
+
+    for i in range(10):
+        time.sleep(1.0)
+        set_progress(1+1, 10)

--- a/static/index.html
+++ b/static/index.html
@@ -36,11 +36,30 @@
           </div>
         </div>
         <div class="row mb-3">
-          <div class="col-md-6"></div>
-          <div class="col-md-2">
+          <div class="col-md-8">
+            <div class="row">
+              <div class="col-md-12">
+                <div class="spinner-border spinner-border-sm text-primary d-none" role="status" id="execution-status-spinner">
+                  <span class="visually-hidden">Executing...</span>
+                </div>
+                <span id="execution-status-text" align="left"></span>
+                <span id="execution-status-progress" align="left"></span>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <div class="progress d-none" id="execution-progress" style="height: 12px;">
+                  <div class="progress-bar progress-bar-striped progress-bar-animated"
+                    id="execution-progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-1">
             <button type="submit" class="btn btn-primary" onclick="abort_sequence()" id="abort-btn">Abort</button>
           </div>
-          <div class="col-md-2">
+          <div class="col-md-1">
             <button type="submit" class="btn btn-primary" onclick="reload_modules()" id="reload-btn">Reload</button>
           </div>
           <div class="col-md-2" align="center">

--- a/static/js/command_sequencer.js
+++ b/static/js/command_sequencer.js
@@ -4,6 +4,11 @@ let sequence_modules = {};
 let is_executing;
 let sequencer_endpoint;
 let detect_changes_switch  = document.getElementById('detect-module-changes-toggle');
+let execution_spinner = document.getElementById("execution-status-spinner");
+let execution_text = document.getElementById("execution-status-text");
+let execution_progress = document.getElementById("execution-progress");
+let execution_progress_bar = document.getElementById("execution-progress-bar");
+let execution_status_progress = document.getElementById("execution-status-progress");
 
 const ALERT_ID = {
     'sequencer_error': '#command-sequencer-error-alert',
@@ -38,12 +43,14 @@ document.addEventListener("DOMContentLoaded", function () {
         if (is_executing) {
             disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, true);
             disable_buttons(`${BUTTON_ID['abort']}`, false);
+            display_execution(result.execute);
             await_execution_complete();
             await_process_execution_complete();
         }
         else
         {
             disable_buttons(`${BUTTON_ID['abort']}`, true);
+            hide_execution();
         }
 
         set_detect_module_changes_toggle(detect_module_modifications);
@@ -191,6 +198,7 @@ function execute_sequence(button) {
             hide_alerts(`${ALERT_ID['sequencer_info']},${ALERT_ID['sequencer_error']},.sequence-alert`);
             disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, true);
             disable_buttons(`${BUTTON_ID['abort']}`, false);
+            display_execution(`${seq_module_name}/${seq_name}`);
 
             sequencer_endpoint.put({ 'execute': seq_name })
             .catch(error => {
@@ -220,6 +228,7 @@ function execute_sequence(button) {
     } else {
         disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, true);
         disable_buttons(`${BUTTON_ID['abort']}`, false);
+        hide_execution();
         sequencer_endpoint.put({ 'execute': seq_name })
         .catch(error => {
             alert_message = error.message;
@@ -294,10 +303,12 @@ function await_execution_complete() {
         display_log_messages();
         is_executing = result.is_executing
         if (is_executing) {
-            setTimeout(await_execution_complete, 1000);
+            update_execution_progress();
+            setTimeout(await_execution_complete, 500);
         } else {
             disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, false);
             disable_buttons(`${BUTTON_ID['abort']}`, true);
+            hide_execution();
         }
     });
 }
@@ -339,6 +350,57 @@ function hide_alerts(alert_id_or_ids) {
         element.classList.add('d-none');
     });
     //$(alert_id_or_ids).addClass('d-none').html('');
+}
+
+/*
+ * This function displays the excution progress elements on the UI
+ */
+function display_execution(sequence_name)
+{
+    execution_spinner.classList.remove('d-none');
+    execution_text.innerHTML = "<b>Executing:&nbsp;" + sequence_name + "</b>";
+    execution_progress_bar.style.width = "0%";
+    execution_progress_bar.setAttribute('aria-valuenow', 0);
+    execution_status_progress.innerHTML = ""
+
+    execution_progress.classList.remove('d-none');
+}
+
+/*
+ * This function hides the eexcution progress elements on the UI
+ */
+function hide_execution()
+{
+    execution_progress.classList.add('d-none');
+    execution_spinner.classList.add('d-none');
+    execution_text.innerHTML = "";
+    execution_status_progress.innerHTML = "";
+}
+
+/*
+ * This function updates the execution progress bar
+ */
+
+function update_execution_progress()
+{
+    sequencer_endpoint.get('execution_progress')
+    .then(result => {
+        console.log(result)
+        var current = result.execution_progress.current;
+        var total = result.execution_progress.total;
+        if (total != -1)
+        {
+            var percent_complete = Math.floor((100.0 * current) / total);
+            execution_progress_bar.style.width = percent_complete + "%";
+            execution_progress_bar.setAttribute('aria-valuenow', percent_complete);
+            execution_status_progress.innerHTML = "<b>(" + current + "/" + total + ")</b>";
+        }
+        else
+        {
+            execution_progress_bar.style.width = "100%";
+            execution_status_progress.innerHTML = "";
+        }
+    });
 }
 
 /**

--- a/static/js/command_sequencer.js
+++ b/static/js/command_sequencer.js
@@ -228,7 +228,7 @@ function execute_sequence(button) {
     } else {
         disable_buttons(`${BUTTON_ID['all_execute']},${BUTTON_ID['reload']}`, true);
         disable_buttons(`${BUTTON_ID['abort']}`, false);
-        hide_execution();
+        display_execution(`${seq_module_name}/${seq_name}`);
         sequencer_endpoint.put({ 'execute': seq_name })
         .catch(error => {
             alert_message = error.message;
@@ -385,7 +385,6 @@ function update_execution_progress()
 {
     sequencer_endpoint.get('execution_progress')
     .then(result => {
-        console.log(result)
         var current = result.execution_progress.current;
         var total = result.execution_progress.total;
         if (total != -1)


### PR DESCRIPTION
This PR address #40 and adds the ability to display sequence execution progress to the user. Sequences can optionally call `report_progress(current, total)` to set the current and total number of execution steps. This will be displayed in the UI as a progress bar. The UI also reports the name of the currently executing sequence.

Closes #40 
