### PR TITLE
Improved list handling in parse_parameter_value.

### DIFF
--- a/static/js/command_sequencer.js
+++ b/static/js/command_sequencer.js
@@ -270,7 +270,12 @@ function get_input_parameter_values(params) {
  */
 function parse_parameter_value(param_val, param_type) {
     if (param_type.startsWith('list')) {
-        param_type = 'list';
+        const elementType = param_type.split("list-");
+        param_val = param_val.split(',');
+
+        return param_val.map(function (element) {
+            return parse_parameter_value(element.trim(), elementType[1]);
+        })
     }
 
     switch (param_type) {
@@ -281,10 +286,7 @@ function parse_parameter_value(param_val, param_type) {
             param_val = parseFloat(param_val);
             break;
         case 'bool':
-            param_val = param_val == 'True';
-            break;
-        case 'list':
-            param_val = param_val.split(',');
+            param_val = param_val.toLowerCase() == 'true';
             break;
     }
 


### PR DESCRIPTION
Made changes so the default value for spi_write does not raise an error

Uses a map function to convert lists to their correct datatypes.

Removed the list switch case as it is now handled above it.

Added toLowerCase to the bool case as default values in JS are not capitalised.


Resolves #46 