### PR TITLE
Changed odin_server command to odin_control in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Run the odin server while in the odin-sequencer directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code-block:: bash
 
-    $ odin_server --config config/odin_sequencer.cfg 
+    $ odin_control --config config/odin_sequencer.cfg 
 
 Access the UI by navigating to :code:`localhost:8888` in your browser
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
"The odin_server script entry point is deprecated and will be removed in future releases. Consider using 'odin_control' instead"