### PR TITLE
75/76 Modal Type Handling

### DIFF
--- a/app/odin-sequencer-react-ui/lib/components/ModalParams.jsx
+++ b/app/odin-sequencer-react-ui/lib/components/ModalParams.jsx
@@ -3,6 +3,7 @@ import { WithEndpoint } from "odin-react";
 
 /* Constructing the labels and input boxes for the parameters inside the modal. */
 const EndpointFormControl = WithEndpoint(Form.Control);
+const EndpointFormCheck = WithEndpoint(Form.Check);
 
 function ModalParams ({endpoint, sequenceConfig, sequenceName, moduleName}) {
   return (
@@ -12,15 +13,26 @@ function ModalParams ({endpoint, sequenceConfig, sequenceName, moduleName}) {
         const paramName = `${paramKey.replaceAll(' ', '_')} (${param.type})`;
 
         return (
-          <Form.Group as={Row} className="mb-2" key={paramLabel}>
+          <Form.Group as={Row} className="mb-2 d-flex align-items-stretch" key={paramLabel}>
             <Form.Label column sm={5}>
               {paramName}
             </Form.Label>
             <Col sm={7}>
-              <EndpointFormControl
-                endpoint={endpoint}
-                fullpath={`sequence_modules/${moduleName}/${sequenceName}/${paramKey}/value`}
-              />
+              {
+                // Check if the type of the endpoint is boolean. If it is, render a toggle switch instead of a formcontrol
+                param.type === 'bool' ? 
+                  <EndpointFormCheck
+                    type="switch"
+                    endpoint={endpoint}
+                    fullpath={`sequence_modules/${moduleName}/${sequenceName}/${paramKey}/value`}
+                    className="w-100 h-100 d-flex align-items-center"
+                  />
+                :
+                  <EndpointFormControl
+                    endpoint={endpoint}
+                    fullpath={`sequence_modules/${moduleName}/${sequenceName}/${paramKey}/value`}
+                  />
+              }
             </Col>
           </Form.Group>
         );

--- a/src/odin_sequencer/manager.py
+++ b/src/odin_sequencer/manager.py
@@ -20,6 +20,8 @@ from .exceptions import CommandSequenceError
 from .watcher import FileWatcherFactory
 from .sequence_logger import SequenceLogger
 
+import logging
+
 if sys.version_info < (3, 6, 0):  # pragma: no cover
     class ModuleNotFoundError(ImportError):  # pylint: disable=redefined-builtin
         """Derive ModuleNotFoundError exception for earlier python versions."""
@@ -250,19 +252,40 @@ class CommandSequenceManager:
         return not any(not type(element) == type(list_val[0]) for element in list_val)
 
     def _build_sequence_parameter_info(self, params):
-        """This method builds a dictionary that contains the parameter
-        names that a sequence accepts, and their type and default value.
+        """This method builds a dictionary that contains the parameter names that a sequence
+        accepts, with their type, default, and current value.
+        The current value is implemented with a lambda function to make it settable with typical
+        ParameterTree type handling.
 
         :param params: the parameter(s) to extract and build information for
         :return: a dictionary with information about the parameters that the sequence accepts
-        """
-        return {
-            param.name: {
+        """        
+        sequence_info = {}
+
+        for param in params:
+            param_info = {
                 "value": param.default,
                 "default": param.default,
                 "type": self._get_parameter_type(param.default)
-            } for param in params
-        }
+            }
+            sequence_info[param.name] = {
+                "value": (
+                    lambda p=param_info: p["value"],
+                    partial(self._set_sequence_param_value, param_info)
+                ),
+                "default": param_info["default"],
+                "type": param_info["type"]
+            }
+
+        return sequence_info
+
+    def _set_sequence_param_value(self, param_info, value):
+        """This method sets the value of a sequence parameter in the tree."""
+        if self._is_executing:
+            raise CommandSequenceError(
+                "Cannot set parameter value while sequence is executing"
+            )
+        param_info["value"] = value
 
     @staticmethod
     def _get_parameter_type(param_default_val):


### PR DESCRIPTION
Addressing issues #75 and #76 as they are somewhat related.

#75: the parameter tree for sequences now uses a proper setter which will make type handling consistent with other adapters and allow for coersion as needed (such as allowing integers to be submitted to float type parameters).

#76: booleans are now represented by a toggle instead of a text field. The field did work but it always appeared 'dirty' after the initial submission and was generally not how you're supposed to handle those.

<img width="681" height="509" alt="image" src="https://github.com/user-attachments/assets/2dfd523d-61b8-4d6c-93b2-194c61d341f4" />

I'll make a corresponding branch/PR on the odin-sequencer-ui side for the boolean change and link it here before I merge this change.